### PR TITLE
Add initial recording of test results and other analytics

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,10 +25,20 @@ node ("default-java") {
         archiveArtifacts 'gradlew, gradle/wrapper/*, modules/Core/build.gradle, config/**, build/distributions/Terasology.zip, build/resources/main/org/terasology/version/versionInfo.properties, natives/**'
     }
     
+    stage('Analytics') {
+        sh './gradlew check'
+    }
+    
     stage('Publish') {
         withCredentials([usernamePassword(credentialsId: 'artifactory-gooey', usernameVariable: 'artifactoryUser', passwordVariable: 'artifactoryPass')]) {
             sh './gradlew -Dorg.gradle.internal.publish.checksums.insecure=true publish -PmavenUser=${artifactoryUser} -PmavenPass=${artifactoryPass}'
         }
+    }
+    
+    stage('Record') {
+        junit testResults: 'build/test-results/test/*.xml'
+        recordIssues aggregatingResults: true, tool: checkStyle(pattern: 'build/reports/checkstyle/*.xml')
+        recordIssues aggregatingResults: true, tool: [javaDoc()]
     }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,8 +6,8 @@ node ("default-java") {
     }
 
     stage('Prep workspace') {
-        copyArtifacts(projectName: "Terasology/engine/develop", filter: "modules/Core/build.gradle", flatten: true, selector: lastSuccessful())
-        copyArtifacts(projectName: "Terasology/engine/develop", filter: "*, gradle/wrapper/**, config/**, natives/**", selector: lastSuccessful())
+        copyArtifacts(projectName: "Nanoware/Terasology/develop", filter: "modules/Core/build.gradle", flatten: true, selector: lastSuccessful())
+        copyArtifacts(projectName: "Nanoware/Terasology/develop", filter: "*, gradle/wrapper/**, config/**, natives/**", selector: lastSuccessful())
         def realProjectName = findRealProjectName()
         echo "Real project name: $realProjectName"
         sh """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,15 +1,15 @@
 node ("default-java") {
 
-    stage('Checkout') {
+    stage('Prepare') {
         echo "Going to check out the things !"
         checkout scm
-    }
 
-    stage('Prep workspace') {
+        echo "Copying in the build harness from an engine job"
         copyArtifacts(projectName: "Nanoware/Terasology/develop", filter: "modules/Core/build.gradle", flatten: true, selector: lastSuccessful())
         copyArtifacts(projectName: "Nanoware/Terasology/develop", filter: "*, gradle/wrapper/**, config/**, natives/**", selector: lastSuccessful())
+
         def realProjectName = findRealProjectName()
-        echo "Real project name: $realProjectName"
+        echo "Setting real project name to: $realProjectName"
         sh """
             ls
             rm -f settings.gradle

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ node ("default-java") {
     }
     
     stage('Analytics') {
-        sh './gradlew --stacktrace check'
+        sh './gradlew check'
     }
     
     stage('Publish') {
@@ -37,8 +37,12 @@ node ("default-java") {
     
     stage('Record') {
         junit testResults: 'build/test-results/test/*.xml'
-        recordIssues aggregatingResults: true, tool: checkStyle(pattern: 'build/reports/checkstyle/*.xml')
-        recordIssues aggregatingResults: true, tool: javaDoc()
+        recordIssues tool: javaDoc()
+        step([$class: 'JavadocArchiver', javadocDir: 'build/docs/javadoc', keepAll: false])
+        recordIssues tool: checkStyle(pattern: 'build/reports/checkstyle/*.xml')
+        recordIssues tool: spotBugs(pattern: '**/build/reports/spotbugs/*.xml', useRankAsPriority: true)
+        recordIssues tool: pmdParser(pattern: '**/reports/pmd/*.xml')
+        recordIssues tool: taskScanner(includePattern: '**/*.java,**/*.groovy,**/*.gradle', lowTags: 'WIBNIF', normalTags: 'TODO', highTags: 'ASAP')
     }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,17 +36,17 @@ node ("default-java") {
     }
     
     stage('Record') {
-        junit testResults: 'build/test-results/test/*.xml'
+        junit testResults: 'build/test-results/test/*.xml',  allowEmptyResults: true
         recordIssues tool: javaDoc()
         step([$class: 'JavadocArchiver', javadocDir: 'build/docs/javadoc', keepAll: false])
-        recordIssues tool: checkStyle(pattern: 'build/reports/checkstyle/*.xml')
+        recordIssues tool: checkStyle(pattern: '**/build/reports/checkstyle/*.xml')
         recordIssues tool: spotBugs(pattern: '**/build/reports/spotbugs/*.xml', useRankAsPriority: true)
-        recordIssues tool: pmdParser(pattern: '**/reports/pmd/*.xml')
+        recordIssues tool: pmdParser(pattern: '**/build/reports/pmd/*.xml')
         recordIssues tool: taskScanner(includePattern: '**/*.java,**/*.groovy,**/*.gradle', lowTags: 'WIBNIF', normalTags: 'TODO', highTags: 'ASAP')
     }
 }
 
-def String findRealProjectName() {
+String findRealProjectName() {
     def jobNameParts = env.JOB_NAME.tokenize('/') as String[]
     println "Job name parts: $jobNameParts"
     return jobNameParts.length < 2 ? env.JOB_NAME : jobNameParts[jobNameParts.length - 2]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,7 @@ node ("default-java") {
     stage('Record') {
         junit testResults: 'build/test-results/test/*.xml'
         recordIssues aggregatingResults: true, tool: checkStyle(pattern: 'build/reports/checkstyle/*.xml')
-        recordIssues aggregatingResults: true, tool: [javaDoc()]
+        recordIssues aggregatingResults: true, tool: javaDoc()
     }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ node ("default-java") {
     }
     
     stage('Analytics') {
-        sh './gradlew check'
+        sh './gradlew --stacktrace check'
     }
     
     stage('Publish') {


### PR DESCRIPTION
Just junit, Checkstyle, and Javadoc so far (oddly just _warnings_ from Javadoc generation, didn't find the bit that'd publish the actual Javadoc. Definitely more to do, but gets a start going.

TODO: Flip back to live job name instead of test (or ideally make that dynamic based on Folder config in Jenkins). Possibly consider using SonarSource instead additionally or alternatively? Might especially go well with lighter builds powered by GitHub actions.