### PR TITLE
Re-enable unit test reporting with an MTE fix in place and re-simplify phases

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,20 +25,6 @@ node ("default-java || light-java") {
         archiveArtifacts 'gradlew, gradle/wrapper/*, templates/build.gradle, config/**, build/distributions/Terasology.zip, build/resources/main/org/terasology/version/versionInfo.properties, natives/**'
     }
 
-    stage('Test') {
-        // Keep tests in a separate stage to cope with failing MTE
-        sh './gradlew test'
-    }
-
-    stage('Analytics') {
-        // Run analytics like Checkstyle or PMD without running tests
-        sh './gradlew check -x test spotbugsmain'
-    }
-
-    stage('JavaDoc') {
-        sh './gradlew javadoc'
-    }
-
     stage('Publish') {
         if (env.BRANCH_NAME.equals("master") || env.BRANCH_NAME.equals("develop")) {
             withCredentials([usernamePassword(credentialsId: 'artifactory-gooey', usernameVariable: 'artifactoryUser', passwordVariable: 'artifactoryPass')]) {
@@ -49,31 +35,21 @@ node ("default-java || light-java") {
         }
     }
 
+    stage('Analytics') {
+        sh './gradlew check spotbugsmain javadoc'
+    }
+    
     stage('Record') {
         // Test for the presence of Javadoc so we can skip it if there is none (otherwise would fail the build)
         if (fileExists("build/docs/javadoc/index.html")) {
             step([$class: 'JavadocArchiver', javadocDir: 'build/docs/javadoc', keepAll: false])
             recordIssues tool: javaDoc()
         }
-        //TODO: Figure out how to collect test results without failing the build/making it unstable
-        //      Don't collect the tests results as this will (most often) make the build UNSTABLE, which in turn
-        //      will turn the Github status to be failed.
-        // junit testResults: 'build/test-results/test/*.xml', allowEmptyResults: true, healthScaleFactor: 0.0
+        junit testResults: 'build/test-results/test/*.xml', allowEmptyResults: true, healthScaleFactor: 0.0
         recordIssues tool: checkStyle(pattern: '**/build/reports/checkstyle/*.xml')
         recordIssues tool: spotBugs(pattern: '**/build/reports/spotbugs/main/*.xml', useRankAsPriority: true)
         recordIssues tool: pmdParser(pattern: '**/build/reports/pmd/*.xml')
         recordIssues tool: taskScanner(includePattern: '**/*.java,**/*.groovy,**/*.gradle', lowTags: 'WIBNIF', normalTags: 'TODO', highTags: 'ASAP')
-
-        //TODO: This makes a second check on Github instead of updating the job-related one
-        //      Mark UNSTABLE builds as SUCCESS on Github.
-        step([
-            $class: 'GitHubCommitStatusSetter',
-            statusResultSource: [
-                $class: 'ConditionalStatusResultSource',
-                results: [[$class: 'BetterThanOrEqualBuildResult', message: '', result: 'UNSTABLE', state: 'SUCCESS']]
-            ]
-        ])
-
     }
 }
 


### PR DESCRIPTION
Tested alongside 

* https://github.com/MovingBlocks/Terasology/pull/4066
* https://github.com/Terasology/ModuleTestingEnvironment/pull/16
* https://github.com/Terasology/ModuleTestingEnvironment/pull/17

Tests work beautifully! Or at least those that actually pass. Which should mean any remaining test failures on PRs are legit and should indeed mark a commit status problem.

Publish still goes before analytics, which may seem odd, but we don't have any gates active on the analytics yet so ... one day!