### PR TITLE
JTE v2 upgrade and improvements

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,9 +8,17 @@ node ("ts-module && heavy && java8") {
         echo "Going to check out the things !"
         checkout scm
 
-        echo "Copying in the build harness from an engine job"
-        copyArtifacts(projectName: "Terasology/engine/develop", filter: "templates/build.gradle", flatten: true, selector: lastSuccessful())
-        copyArtifacts(projectName: "Terasology/engine/develop", filter: "*, gradle/wrapper/**, config/**, natives/**, build-logic/**", selector: lastSuccessful())
+        // Vary where we copy the build harness from based on where the actively running job lives
+        def buildHarnessOrigin = "Terasology/engine/develop"
+        if (env.JOB_NAME.startsWith("Nanoware/TerasologyModules/H")) { // "Normal" module tests with the regular build harness in Nanoware land
+            buildHarnessOrigin = "Nanoware/Terasology/develop"
+        } else if (env.JOB_NAME.startsWith("Nanoware/TerasologyModules/X")) { // Unusual module tests with separate build harness (and JteConfig branch - defined elsewhere)
+            buildHarnessOrigin = "Nanoware/Terasology/experimental"
+        }
+
+        echo "Copying in the build harness from an engine job: $buildHarnessOrigin"
+        copyArtifacts(projectName: buildHarnessOrigin, filter: "templates/build.gradle", flatten: true, selector: lastSuccessful())
+        copyArtifacts(projectName: buildHarnessOrigin, filter: "*, gradle/wrapper/**, config/**, natives/**, build-logic/**", selector: lastSuccessful())
 
         def realProjectName = findRealProjectName()
         echo "Setting real project name to: $realProjectName"

--- a/pipeline_config.groovy
+++ b/pipeline_config.groovy
@@ -1,7 +1,4 @@
 // restrict individual repository Jenkinsfiles
-allow_scm_jenkinsfile = false
-
-libraries {
-  //merge = false // disallow individual repos to contribute additional libraries
-  moduleBuild
+jte {
+  allow_scm_jenkinsfile = false
 }


### PR DESCRIPTION
Makes the choice of build harness conditional on environment (no more need to keep a commit that redirects the Nanoware fork)

Removes some placeholder JTE code we don't actually use anyway

The "Replay" button in individual module build jobs in Jenkins now actually loads the Jenkinsfile (or an edited replay, I imagine) rather than the `template()` thing

Goes with some changes in the infra repo that also adjusts the Job DSL that creates the module mega-jobs that use this Jenkinsfile.

Additionally I've made it easier to test stuff, now with two "streams" so to say under Nanoware.

https://jenkins.terasology.io/teraorg/job/Nanoware/job/Terasology/job/develop/ builds the Nanoware `develop` branch normally, attaching a build harness, that is then being used by https://github.com/Nanoware/ModuleJteConfig/tree/develop - making that the new default branch instead of `master`

https://jenkins.terasology.io/teraorg/job/Nanoware/job/Terasology/job/experimental/ is available now to push any changes that _change_ the build harness _and_ will be used by https://github.com/Nanoware/ModuleJteConfig/tree/experimental

In the end that means the Nanoware module builds at https://jenkins.terasology.io/teraorg/job/Nanoware/job/TerasologyModules/job/H/ are based on the `develop` branches and the set at https://jenkins.terasology.io/teraorg/job/Nanoware/job/TerasologyModules/job/X/ uses the `experimental` branches.

That's still not PR-level automated testing, but just push to the `experimental` branches in place of PRs if wanting to test that sort of stuff.

When this is merged we should then rename the target `master` branch to `develop`