### PR TITLE
feat: report status of java compilation as `stage/Build`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,6 +49,10 @@ pipeline {
         stage('Setup') {
             steps {
                 echo 'Automatically checked out the things!'
+                // the default resolution when omitting `defaultBranch` is to `master`
+                // this is wrong in our case, so explicitly set `develop` as default
+                // TODO: does this also work for PRs with different base branch?
+                discoverGitReferenceBuild(defaultBranch: 'develop')
 
                 echo "Copying in the build harness from an engine job: $buildHarnessOrigin"
                 copyArtifacts(projectName: buildHarnessOrigin, filter: "templates/build.gradle", flatten: true, selector: lastSuccessful())
@@ -130,10 +134,6 @@ pipeline {
             }
             post {
                 always {
-                    // the default resolution when omitting `defaultBranch` is to `master`
-                    // this is wrong in our case, so explicitly set `develop` as default
-                    // TODO: does this also work for PRs with different base branch?
-                    discoverGitReferenceBuild(defaultBranch: 'develop')
                     recordIssues skipBlames: true,
                     tools: [
                         checkStyle(pattern: '**/build/reports/checkstyle/*.xml'),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,7 +73,7 @@ pipeline {
         stage('Build') {
             steps {
                 // Jenkins sometimes doesn't run Gradle automatically in plain console mode, so make it explicit
-                sh './gradlew --console=plain clean htmlDependencyReport'
+                sh label: 'determining dependencies', script: './gradlew --console=plain clean htmlDependencyReport'
 
                 // Reporting this compile task as `stage/Build` for backwards compatibility with things configured
                 // to watch for CloudBees SCM Reporting stage status.


### PR DESCRIPTION
as a replacement for CloudBees reporting every Stage.

This is currently on Nanoware/develop. Example: https://github.com/Nanoware/Health/pull/1