### PR TITLE
build: check the Jenkinsfile

### DIFF
--- a/self.Jenkinsfile
+++ b/self.Jenkinsfile
@@ -1,0 +1,18 @@
+// This repo exports `Jenkinsfile` for module builds.
+// This file is to do some very basic checks on that file, to catch errors earlier.
+
+pipeline {
+    agent { label 'master' }
+    stages {
+        stage('Syntax Check') {
+            steps {
+                script {
+                    boolean isValid = validateDeclarativePipeline 'Jenkinsfile'
+                    if (!isValid) {
+                        error("Validation failed.")
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
trying to catch errors earlier when we make revisions to ModuleJteConfig

this does require a corresponding build to be set up in Jenkins. I haven't written JobDSL for it yet, but here is proof of concept in [Nanoware/ModuleJteConfig](https://jenkins.terasology.io/teraorg/job/Nanoware/job/ModuleJteConfig/view/change-requests/job/PR-3/)