### PR TITLE
build: use java 11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,6 +67,7 @@ pipeline {
                     echo 'includeBuild("build-logic")' >> settings.gradle
                 """
                 sh 'chmod +x gradlew'
+                sh './gradlew --version'
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ properties([
  */
 pipeline {
     agent {
-        label 'ts-module && heavy && java8'
+        label 'ts-module && heavy && java11'
     }
     stages {
          // declarative pipeline does `checkout scm` automatically when hitting first stage


### PR DESCRIPTION
The first step in changing our minimum build requirements from Java 8 to Java 11.

Successfully tested on Nanoware: https://jenkins.terasology.io/teraorg/job/Nanoware/job/TerasologyModules/job/H/job/Health/job/develop/