### PR TITLE
fix: publish javadoc on jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -162,7 +162,7 @@ pipeline {
                 sh './gradlew --console=plain javadoc'
                 script {
                     if (fileExists("build/docs/javadoc/index.html")) {
-                        javaDoc javadocDir: 'build/docs/javadoc', keepAll: false
+                        javadoc javadocDir: 'build/docs/javadoc', keepAll: false
                         recordIssues skipBlames: true, tool: javaDoc()
                     }
                 }


### PR DESCRIPTION
The javadoc for a module should be available from its branch's page on Jenkins in the sidebar.

Note that the **Javadoc** entry is different than **JavaDoc Warnings**, which is _about_ the JavaDoc, or **Docs**, which is whatever is in the  `docs/` directory (such as Docsify pages).

![jenkins-javadoc-sidebar](https://user-images.githubusercontent.com/83819/140426638-4441aaf1-d66f-441b-a1a2-3adbdbd390f9.png)
