### PR TITLE
feat: run all checks, even if one fails

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -139,7 +139,7 @@ pipeline {
 
         stage('Analytics') {
             steps {
-                sh './gradlew --console=plain check -x test'
+                sh './gradlew --console=plain check -x test --continue'
             }
             post {
                 always {


### PR DESCRIPTION
As it is, a PR like https://github.com/Terasology/FlexiblePathfinding/pull/24 gets through the CheckStyle task and then stops.

I figure as long as we have it running, we might as well get feedback from all the checks, so the others don't come as a surprise once the style errors are fixed.