### PR TITLE
ci: use java17 builder

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ properties([
  */
 pipeline {
     agent {
-        label 'ts-module && heavy && java11'
+        label 'ts-module && heavy && java17'
     }
     stages {
          // declarative pipeline does `checkout scm` automatically when hitting first stage


### PR DESCRIPTION
This is a complementary pull request to https://github.com/MovingBlocks/Terasology/pull/5162, which should ensure that modules are also built with Java 17.